### PR TITLE
Add entry points for rendering

### DIFF
--- a/.storybook/helpers/Renderer.js
+++ b/.storybook/helpers/Renderer.js
@@ -12,39 +12,53 @@ import 'ory-editor-core/lib/index.css' // we also want to load the stylesheets
 import { Trash, DisplayModeToggle, Toolbar } from 'ory-editor-ui'
 import 'ory-editor-ui/lib/index.css'
 
-// Load some exemplary plugins:
-import slate from 'ory-editor-plugins-slate' // The rich text area plugin
-
-import 'ory-editor-plugins-slate/lib/index.css' // Stylesheets for the rich text area plugin
-
-import spacer from 'ory-editor-plugins-spacer'
-import 'ory-editor-plugins-spacer/lib/index.css'
-import infobox from 'ory-editor-plugins-infobox'
-import 'ory-editor-plugins-infobox/lib/index.css'
-import highlight from 'ory-editor-plugins-highlight'
-import 'ory-editor-plugins-highlight/lib/index.css'
-import geogebra from 'ory-editor-plugins-geogebra'
-import 'ory-editor-plugins-geogebra/lib/index.css'
+import slate from 'ory-editor-plugins-slate'
+import 'ory-editor-plugins-slate/lib/index.css'
 import divider from 'ory-editor-plugins-divider'
 import 'ory-editor-plugins-divider/lib/index.css'
+import spacer from 'ory-editor-plugins-spacer'
+import 'ory-editor-plugins-spacer/lib/index.css'
 import image from 'ory-editor-plugins-image'
 import 'ory-editor-plugins-image/lib/index.css'
 import video from 'ory-editor-plugins-video'
 import 'ory-editor-plugins-video/lib/index.css'
 
+import infobox from 'ory-editor-plugins-infobox/src'
+import infoboxRender from 'ory-editor-plugins-infobox/src/index.render'
+import 'ory-editor-plugins-infobox/src/index.css'
+import highlight from 'ory-editor-plugins-highlight/src'
+import highlightRender from 'ory-editor-plugins-highlight/src/index.render'
+import 'ory-editor-plugins-highlight/src/index.css'
+import geogebra from 'ory-editor-plugins-geogebra/src'
+import geogebraRender from 'ory-editor-plugins-geogebra/src/index.render'
+import 'ory-editor-plugins-geogebra/src/index.css'
+
 require('react-tap-event-plugin')() // react-tap-event-plugin is required by material-ui which is used by ory-editor-ui so we need to call it here
 
 // Define which plugins we want to use. We only have slate and parallax available, so load those.
-const plugins = {
-  content: [slate(), spacer, image, video, divider, geogebra, highlight], // Define plugins for content cells
+const editorPlugins = {
+  content: [slate(), spacer, image, video, divider, geogebra, highlight],
   layout: [infobox({ defaultPlugin: slate() })]
+}
+
+const renderPlugins = {
+  content: [
+    slate(),
+    spacer,
+    image,
+    video,
+    divider,
+    geogebraRender,
+    highlightRender
+  ],
+  layout: [infoboxRender({ defaultPlugin: slate() })]
 }
 
 export class Renderer {
   constructor(content) {
     this.content = content
     this.editor = new Editor({
-      plugins,
+      plugins: editorPlugins,
       // pass the content state - you can add multiple editables here
       editables: [content]
     })
@@ -67,6 +81,6 @@ export class Renderer {
   }
 
   renderHTMLRenderer() {
-    return <HTMLRenderer state={this.content} plugins={plugins} />
+    return <HTMLRenderer state={this.content} plugins={renderPlugins} />
   }
 }

--- a/plugins/content/geogebra/src/index.js
+++ b/plugins/content/geogebra/src/index.js
@@ -1,11 +1,12 @@
 import React from 'react'
-import Geogebra from './Component'
 import Panorama from 'material-ui/svg-icons/toggle/star'
 
+import Geogebra from './Component'
+import plugin from './plugin'
+
 export default {
+  ...plugin,
   Component: Geogebra,
-  name: 'serlo/content/geogebra',
-  version: '0.0.1',
   IconComponent: <Panorama />,
   text: 'Geogebra'
 }

--- a/plugins/content/geogebra/src/index.render.js
+++ b/plugins/content/geogebra/src/index.render.js
@@ -1,0 +1,7 @@
+import Geogebra from './Component/Display'
+import plugin from './plugin'
+
+export default {
+  ...plugin,
+  Component: Geogebra
+}

--- a/plugins/content/geogebra/src/plugin.js
+++ b/plugins/content/geogebra/src/plugin.js
@@ -1,0 +1,4 @@
+export default {
+  name: 'serlo/content/geogebra',
+  version: '0.0.1'
+}

--- a/plugins/content/highlight/src/Component/Display/index.js
+++ b/plugins/content/highlight/src/Component/Display/index.js
@@ -1,0 +1,22 @@
+import React, { Component } from 'react'
+import SyntaxHighlight from 'react-syntax-highlighter'
+import { light } from 'react-syntax-highlighter/styles/prism'
+
+class Display extends Component {
+  render() {
+    const { state } = this.props
+    const { text, language, lineNumbers } = state
+
+    return (
+      <SyntaxHighlight
+        language={language || 'text'}
+        showLineNumbers={lineNumbers || false}
+        style={light}
+      >
+        {text || 'Switch into edit mode then paste your sourcecode here...'}
+      </SyntaxHighlight>
+    )
+  }
+}
+
+export default Display

--- a/plugins/content/highlight/src/Component/index.js
+++ b/plugins/content/highlight/src/Component/index.js
@@ -1,13 +1,9 @@
 import React, { Component } from 'react'
+
+import Display from './Display'
 import Input from './Input'
-import SyntaxHighlight from 'react-syntax-highlighter'
-import { light } from 'react-syntax-highlighter/styles/prism'
 
 class Highlight extends Component {
-  constructor(props) {
-    super(props)
-  }
-
   handleValueChange(event) {
     const target = event.target
     const value = target.type === 'checkbox' ? target.checked : target.value
@@ -25,13 +21,7 @@ class Highlight extends Component {
     return (
       <div>
         {readOnly ? (
-          <SyntaxHighlight
-            language={language || 'text'}
-            showLineNumbers={lineNumbers || false}
-            style={light}
-          >
-            {text || 'Switch into edit mode then paste your sourcecode here...'}
-          </SyntaxHighlight>
+          <Display {...this.props} />
         ) : (
           <Input
             handleValueChange={this.handleValueChange.bind(this)}

--- a/plugins/content/highlight/src/index.js
+++ b/plugins/content/highlight/src/index.js
@@ -1,12 +1,12 @@
-import React from 'react'
-import Highlight from './Component'
-
 import InfoIcon from 'material-ui-icons/Code'
+import React from 'react'
+
+import Highlight from './Component'
+import plugin from './plugin'
 
 export default {
+  ...plugin,
   Component: Highlight,
   IconComponent: <InfoIcon />,
-  name: 'schul-cloud/content/highlight',
-  version: '1.0.0',
   text: 'Code Highlight'
 }

--- a/plugins/content/highlight/src/index.render.js
+++ b/plugins/content/highlight/src/index.render.js
@@ -1,0 +1,8 @@
+import Highlight from './Component/Display'
+
+import plugin from './plugin'
+
+export default {
+  ...plugin,
+  Component: Highlight
+}

--- a/plugins/content/highlight/src/plugin.js
+++ b/plugins/content/highlight/src/plugin.js
@@ -1,0 +1,4 @@
+export default {
+  name: 'schul-cloud/content/highlight',
+  version: '1.0.0'
+}

--- a/plugins/layout/infobox/src/Infobox.js
+++ b/plugins/layout/infobox/src/Infobox.js
@@ -1,0 +1,7 @@
+import React from 'react'
+
+const Infobox = ({ children }) => (
+  <div className="ory-editor-plugins-infobox">{children}</div>
+)
+
+export default Infobox

--- a/plugins/layout/infobox/src/index.js
+++ b/plugins/layout/infobox/src/index.js
@@ -1,19 +1,14 @@
+import InfoIcon from 'material-ui-icons/Info'
 import React from 'react'
 import uuid from 'uuid'
 
-// You are obviously not limited to material-ui, but we really enjoy
-// the material-ui icons!
-import InfoIcon from 'material-ui-icons/Info'
-
-const InfoboxPlugin = ({ children }) => (
-  <div className="ory-editor-plugins-infobox">{children}</div>
-)
+import Infobox from './Infobox'
+import plugin from './plugin'
 
 export default ({ defaultPlugin }) => ({
-  Component: InfoboxPlugin,
+  ...plugin,
+  Component: Infobox,
   IconComponent: <InfoIcon />,
-  name: 'schul-cloud/layout/infobox',
-  version: '1.0.0',
   text: 'Infobox',
 
   createInitialChildren: () => ({

--- a/plugins/layout/infobox/src/index.render.js
+++ b/plugins/layout/infobox/src/index.render.js
@@ -1,0 +1,7 @@
+import Infobox from './Infobox'
+import plugin from './plugin'
+
+export default ({ defaultPlugin }) => ({
+  ...plugin,
+  Component: Infobox
+})

--- a/plugins/layout/infobox/src/plugin.js
+++ b/plugins/layout/infobox/src/plugin.js
@@ -1,0 +1,4 @@
+export default {
+  name: 'schul-cloud/layout/infobox',
+  version: '1.0.0'
+}

--- a/plugins/template/src/index.js
+++ b/plugins/template/src/index.js
@@ -1,1 +1,1 @@
-// plugin definition here... See https://ory.gitbooks.io/editor/content/tutorials.html#writing-plugins for help
+// plugin definition for editing here... See https://ory.gitbooks.io/editor/content/tutorials.html#writing-plugins for help

--- a/plugins/template/src/index.render.js
+++ b/plugins/template/src/index.render.js
@@ -1,0 +1,1 @@
+// plugin definition for rendering here... See https://ory.gitbooks.io/editor/content/tutorials.html#writing-plugins for help


### PR DESCRIPTION
This PR introduces entry points for rendering (for all existing plugins). See the new file `src/index.render` in each file. This file can be used instead of the usual entry point when passed to HTMLRenderer.