### PR TITLE
renaming blockquote component and fix geogebra form bug

### DIFF
--- a/plugins/blockquote/src/blockquote.js
+++ b/plugins/blockquote/src/blockquote.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Editable } from '@splish-me/editor-core/lib/editable.component'
 
-export default class Infobox extends React.Component {
+export default class Blockquote extends React.Component {
   render() {
     const { state } = this.props
     return (

--- a/plugins/geogebra/src/Component/Display/index.js
+++ b/plugins/geogebra/src/Component/Display/index.js
@@ -50,7 +50,7 @@ class Display extends Component {
     })
 
     request
-      .post('http://www.geogebra.org/api/json.php')
+      .post('https://www.geogebra.org/api/json.php')
       .send(geogebraRequest)
       .end((err, res) => {
         if (this.mounted && !err && res.ok) {

--- a/plugins/geogebra/src/Component/Form/index.js
+++ b/plugins/geogebra/src/Component/Form/index.js
@@ -20,7 +20,7 @@ const Form = props => (
             label="Geogebra ID"
             placeholder="1221221"
             onChange={handleChange(props.onChange)}
-            value={props.src}
+            value={props.state.src}
           />
         )
       : null}


### PR DESCRIPTION
The Geogebra plugin didn't show the correct state. So if someone tries to edit an existing applet, the geogebra material id was not set.